### PR TITLE
Bump serverless version to v1.68.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ RUN mkdir -p /tmp/yarn && \
 RUN ln -sf /opt/yarn/dist/bin/yarn /usr/local/bin/yarn && \
   ln -sf /opt/yarn/dist/bin/yarn /usr/local/bin/yarnpkg && \
   yarn --version
-ENV SERVERLESS serverless@1.67.2
+ENV SERVERLESS serverless@1.68.0
 RUN yarn global add $SERVERLESS
 WORKDIR /opt/app


### PR DESCRIPTION
Latest release as per <https://www.npmjs.com/package/serverless>